### PR TITLE
esphome: add support for setting heat recovery bypass temperature

### DIFF
--- a/esphome/Vallox.yaml
+++ b/esphome/Vallox.yaml
@@ -73,6 +73,23 @@ sensor:
     name: vallox_rh2
     device_class: humidity
 
+number:
+  - platform: template
+    id: vallox_t_heat_recovery
+    name: vallox_t_heat_recovery
+    device_class: temperature
+    entity_category: config
+    unit_of_measurement: "°C"
+    min_value: 0
+    max_value: 20
+    step: 1
+    set_action:
+      then:
+        lambda: |-
+          auto ptr = const_cast<custom::CustomClimateConstructor&>(id(my_vallox)).get_climate(0);
+          static_cast<Vallox*>(ptr)->setHeatRecoveryBypassTemp(x);
+
+
 text_sensor:
   - platform: template
     id: vallox_switch_type
@@ -126,6 +143,7 @@ climate:
       id(vallox_heat_target),
       id(vallox_rh1),
       id(vallox_rh2),
+      id(vallox_t_heat_recovery),
       id(vallox_switch_type),
       id(vallox_switch_active),
       id(vallox_heating),


### PR DESCRIPTION
This PR adds support for setting (and getting) the heat recovery bypass temperature (in finnish "LTO kennonohitus"). This is the setting that controls when "summer mode" (= heat recovery bypass) engages.

Lowering the threshold limit is useful in the spring to prevent the summer mode from disengaging during colder nights and then the house becoming too warm during the day, and in the fall/winter you'd want to raise it to keep heat recovery on at all times.

Nb. I'm very new to esphome dev, and my C++ is likewise rusty, but this seems to work for me. :)

![image](https://user-images.githubusercontent.com/170205/234011326-8b708995-e997-4961-960c-10647348bc63.png)
