### PR TITLE
Add number controls for minimum/default and maximum fan speeds

### DIFF
--- a/components/vallox/climate.py
+++ b/components/vallox/climate.py
@@ -51,6 +51,8 @@ CONF_HEAT_BYPASS          = "heat_bypass"
 CONF_SERVICE_RESET        = "service_reset"
 CONF_FAULT_CONDITION      = "fault_condition"
 CONF_SWITCH_TYPE_SELECT   = "switch_type_select"
+CONF_FAN_SPEED_MAX        = "fan_speed_max"
+CONF_FAN_SPEED_MIN        = "fan_speed_min"
 
 # options for the switch type selector (also in vallox.cpp)
 SELECT_SWITCH_TYPE_BOOST     = "boost"
@@ -69,6 +71,8 @@ ValloxVentilation = vallox_ns.class_("ValloxVentilation", climate.Climate, cg.Co
 ValloxVentilationHeatBypassNum       = vallox_ns.class_("ValloxVentilationHeatBypassNum",       number.Number, cg.Component)
 ValloxVentilationServiceResetBtn     = vallox_ns.class_("ValloxVentilationServiceResetBtn",     button.Button, cg.Component)
 ValloxVentilationSwitchTypeSelectSel = vallox_ns.class_("ValloxVentilationSwitchTypeSelectSel", select.Select, cg.Component)
+ValloxVentilationFanSpeedMaxNum      = vallox_ns.class_("ValloxVentilationFanSpeedMaxNum",      number.Number, cg.Component)
+ValloxVentilationFanSpeedMinNum      = vallox_ns.class_("ValloxVentilationFanSpeedMinNum",      number.Number, cg.Component)
 
 CONFIG_SCHEMA = cv.All(
     climate.CLIMATE_SCHEMA.extend(
@@ -194,6 +198,14 @@ CONFIG_SCHEMA = cv.All(
               ValloxVentilationSwitchTypeSelectSel,
               entity_category=ENTITY_CATEGORY_CONFIG,
             ),
+            cv.Optional(CONF_FAN_SPEED_MAX): number.number_schema(
+              ValloxVentilationFanSpeedMaxNum,
+              entity_category=ENTITY_CATEGORY_CONFIG,
+            ),
+            cv.Optional(CONF_FAN_SPEED_MIN): number.number_schema(
+              ValloxVentilationFanSpeedMinNum,
+              entity_category=ENTITY_CATEGORY_CONFIG,
+            ),
         }
     )
     .extend(uart.UART_DEVICE_SCHEMA)
@@ -313,3 +325,25 @@ async def to_code(config):
     cg.add(var.set_switch_type_select_select(sel_switch_type_select_var))
     parent = await cg.get_variable(config[CONF_ID])
     cg.add(sel_switch_type_select_var.set_vallox_parent(parent))
+  if CONF_FAN_SPEED_MAX in config:
+    num_fan_speed_max_var = await number.new_number(
+      config[CONF_FAN_SPEED_MAX],
+      min_value=1,
+      max_value=8,
+      step=1
+    )
+    await cg.register_component(num_fan_speed_max_var, config[CONF_FAN_SPEED_MAX])
+    cg.add(var.set_fan_speed_max_number(num_fan_speed_max_var))
+    parent = await cg.get_variable(config[CONF_ID])
+    cg.add(num_fan_speed_max_var.set_vallox_parent(parent))
+  if CONF_FAN_SPEED_MIN in config:
+    num_fan_speed_min_var = await number.new_number(
+      config[CONF_FAN_SPEED_MIN],
+      min_value=1,
+      max_value=8,
+      step=1
+    )
+    await cg.register_component(num_fan_speed_min_var, config[CONF_FAN_SPEED_MIN])
+    cg.add(var.set_fan_speed_min_number(num_fan_speed_min_var))
+    parent = await cg.get_variable(config[CONF_ID])
+    cg.add(num_fan_speed_min_var.set_vallox_parent(parent))

--- a/components/vallox/vallox.h
+++ b/components/vallox/vallox.h
@@ -51,6 +51,8 @@ namespace esphome {
       class ValloxVentilationHeatBypassNum;
       class ValloxVentilationServiceResetBtn;
       class ValloxVentilationSwitchSelectSel;
+      class ValloxVentilationFanSpeedMaxNum;
+      class ValloxVentilationFanSpeedMinNum;
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
@@ -89,6 +91,32 @@ namespace esphome {
       };
 
 /////////////////////////////////////////////////////////////////////////////////////////
+
+      class ValloxVentilationFanSpeedMaxNum : public number::Number, public Component {
+        public:
+         void set_vallox_parent(ValloxVentilation *parent) { this->parent_ = parent; }
+
+        protected:
+         void control(float value) override;
+
+         ValloxVentilation *parent_;
+      };
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+      class ValloxVentilationFanSpeedMinNum : public number::Number, public Component {
+        public:
+         void set_vallox_parent(ValloxVentilation *parent) { this->parent_ = parent; }
+
+        protected:
+         void control(float value) override;
+
+         ValloxVentilation *parent_;
+      };
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+
 
       class ValloxVentilation : public Component, public climate::Climate, public uart::UARTDevice {
         public:
@@ -130,7 +158,9 @@ namespace esphome {
          void set_error_relay_binary_sensor(binary_sensor::BinarySensor *sensor)      { this->error_relay_binary_sensor_      = sensor; }
          void set_extra_func_binary_sensor(binary_sensor::BinarySensor *sensor)       { this->extra_func_binary_sensor_       = sensor; }
          // number controls
-         void set_heat_bypass_number(number::Number *number) { this->heat_bypass_number_ = number; }
+         void set_heat_bypass_number(number::Number *number)   { this->heat_bypass_number_ = number; }
+         void set_fan_speed_max_number(number::Number *number) { this->fan_speed_max_number_ = number; }
+         void set_fan_speed_min_number(number::Number *number) { this->fan_speed_min_number_ = number; }
          // button controls
          void set_service_reset_button(button::Button *button) { this->service_reset_button_ = button; }
          // select controls
@@ -199,6 +229,8 @@ namespace esphome {
          binary_sensor::BinarySensor *error_relay_binary_sensor_{nullptr};
          binary_sensor::BinarySensor *extra_func_binary_sensor_{nullptr};
          number::Number *heat_bypass_number_{nullptr};
+         number::Number *fan_speed_max_number_{nullptr};
+         number::Number *fan_speed_min_number_{nullptr};
          button::Button *service_reset_button_{nullptr};
          select::Select *switch_type_select_select_{nullptr};
 

--- a/components/vallox/vallox_protocol.h
+++ b/components/vallox/vallox_protocol.h
@@ -2,7 +2,6 @@
 // variables
 #define VX_VARIABLE_STATUS 0xA3
 #define VX_VARIABLE_FAN_SPEED 0x29
-#define VX_VARIABLE_DEFAULT_FAN_SPEED 0xA9
 #define VX_VARIABLE_RH1 0x2F
 #define VX_VARIABLE_RH2 0x30
 #define VX_VARIABLE_SERVICE_PERIOD 0xA6
@@ -18,6 +17,8 @@
 #define VX_VARIABLE_HEATING_STATUS 0x07 // TODO: Not yet implemented
 #define VX_VARIABLE_PROGRAM 0xAA
 #define VX_VARIABLE_T_HEAT_BYPASS 0xAF
+#define VX_VARIABLE_FAN_SPEED_MAX 0xA5
+#define VX_VARIABLE_FAN_SPEED_MIN 0xA9
 
 // Order of these two seems to be that the panel first queries for LO and then HI
 // Query interval is something like 5s by the panel..

--- a/example_vallox.yaml
+++ b/example_vallox.yaml
@@ -50,9 +50,15 @@ climate:
     # sensor for current fan speed (is also visible as custom fan mode in climate component)
     fan_speed:
       name: vallox fan speed
-    # default fan speed (minimum fan speed)
+    # ** DEPRECATED, use fan_speed_min number instead, keeping for backwards compatibility now **  default fan speed (minimum fan speed)
     fan_speed_default:
       name: vallox fan speed default
+    # Maximum fan speed (control / number)
+    fan_speed_max:
+      name: vallox fan speed max
+    # Minimum/Default fan speed (control / number) (same value as fan_speed_default but with control)
+    fan_speed_min:
+      name: vallox fan speed min
     # temperature target, basically not used in my scenario other than having an indication for Home Assistant automations what temperature I would like to have (separate logic could be used with hystereses to heat/cool based on inside temperature and outside temperature)
     temperature_target:
       name: vallox temperature target


### PR DESCRIPTION
- Add number controls for minimum/default and maximum fan speeds
- mark fan_speed_default as deprecated (superseded by fan_speed_min control)